### PR TITLE
Add Term object and autocomplete endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Giphy.translate('geek')
 Giphy.search('funny cat', {limit: 50, offset: 25})
 ````
 
+#### Autocomplete
+````ruby
+Giphy.autocomplete('fun')
+````
+
 #### Favorites
 Write
 ````ruby

--- a/lib/giphy/client.rb
+++ b/lib/giphy/client.rb
@@ -13,6 +13,10 @@ module Giphy
       get('/search', options_hash)
     end
 
+    def autocomplete(keyword)
+      get('/search/tags', q: keyword)
+    end
+
     def favorite(id)
       post("/#{id}/favorites")
     end

--- a/lib/giphy/search.rb
+++ b/lib/giphy/search.rb
@@ -15,6 +15,11 @@ module Giphy
       gif.build_batch_from(result)
     end
 
+    def autocomplete(keyword)
+      result = client.autocomplete(keyword)
+      term.build_batch_from(result)
+    end
+
     def favorite(id)
       result = client.favorite(id)
       favorite_gif.new(result)
@@ -55,6 +60,10 @@ module Giphy
 
     def random_gif
       Giphy::RandomGif
+    end
+
+    def term
+      Giphy::Term
     end
   end
 end

--- a/lib/giphy/term.rb
+++ b/lib/giphy/term.rb
@@ -1,0 +1,23 @@
+module Giphy
+  class Term
+    def self.build_batch_from(array_or_hash)
+      if array_or_hash.is_a?(Array)
+        array_or_hash.map { |term| new(term) }
+      else
+        new(array_or_hash)
+      end
+    end
+
+    def initialize(hash)
+      @hash = hash
+    end
+
+    def name
+      hash.fetch('name')
+    end
+
+    private
+
+    attr_reader :hash
+  end
+end

--- a/lib/giphy/version.rb
+++ b/lib/giphy/version.rb
@@ -1,3 +1,3 @@
 module Giphy
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end

--- a/spec/giphy/client_spec.rb
+++ b/spec/giphy/client_spec.rb
@@ -43,6 +43,16 @@ describe Giphy::Client do
     end
   end
 
+  describe "#autocomplete" do
+    it "does a GET on the 'search/tags' endpoint" do
+      allow(Giphy::Request).
+        to receive(:get).
+        with('/search/tags', { q: 'keyword' }).
+        and_return(api_response)
+      expect(subject.autocomplete('keyword')).to eq(response)
+    end
+  end
+
   describe "#favorite" do
     it "does a POST on the 'favorites' endpoint" do
       allow(Giphy::Request).

--- a/spec/giphy/search_spec.rb
+++ b/spec/giphy/search_spec.rb
@@ -36,6 +36,14 @@ describe Giphy::Search do
     end
   end
 
+  describe "#autocomplete" do
+    it "returns a batch of Terms from the client result" do
+      allow(client).to receive(:autocomplete).with('keyword').and_return(client_result)
+      allow(Giphy::Term).to receive(:build_batch_from).with(client_result).and_return(response)
+      expect(subject.autocomplete('keyword')).to eq response
+    end
+  end
+
   describe "#favorite" do
     it "returns a new FavoriteGifs from the client result" do
       allow(client).to receive(:favorite).with('wdsf34df').and_return(client_result)

--- a/spec/giphy/term_spec.rb
+++ b/spec/giphy/term_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Giphy::Term do
+  let(:invalid_hash) { {} }
+  let(:valid_hash) { { 'name' => 'fooname' } }
+
+  context 'when iniatialized with a valid hash' do
+    subject { described_class.new(valid_hash) }
+
+    its(:name) { should eq(valid_hash['name']) }
+  end
+
+  context 'when initialized with an empty/invalid hash' do
+    subject { described_class.new(invalid_hash) }
+
+    it { expect { subject.name }.to raise_error(KeyError) }
+  end
+
+  describe '.build_batch_from' do
+    subject { described_class.build_batch_from(batch) }
+
+    let(:batch) { [valid_hash, valid_hash] }
+
+    it 'creates a Giphy::Term instance for each array element' do
+      expect(subject.size).to eq(batch.size)
+
+      subject.each { |term| expect(term).to be_a(Giphy::Term) }
+    end
+  end
+end


### PR DESCRIPTION
Provide Term object. [docs](https://developers.giphy.com/docs/api/schema#term-object)
Add  an ability to query autocomplete endpoint wich response with term objects. [docs](https://developers.giphy.com/docs/api/endpoint#autocomplete)